### PR TITLE
adding ability to bind to queue multiple times. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ test:
 
 test-debug:
 	DEBUG=$(DEBUG) \
-	./node_modules/.bin/mocha test -R spec --recursive | bunyan
+	./node_modules/.bin/mocha test -R spec --recursive
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+DEBUG=register-handlers*
+
+test:
+	$(MAKE) DEBUG= test-debug
+
+test-debug:
+	DEBUG=$(DEBUG) \
+	./node_modules/.bin/mocha test -R spec --recursive | bunyan
+
+.PHONY: test

--- a/index.js
+++ b/index.js
@@ -180,13 +180,15 @@ function registerPipeline (options, pipeline) {
 
     if (handler.ack !== isAck) throw new Error('module.exports.ack for %s handlers do not match', firstHandler.queueName || firstHandler.routingKey);
 
+    var queueType = method === 'subscribe' ? 'pubsubqueues' : 'queues';
+
     if (pipeline.handlers.some(function (h) { return handler.routingKey !== h.routingKey; })) {
-      if (bus.pubsubqueues[queueName].listening) {
-        bus.pubsubqueues[queueName].listenChannel.bindQueue(queueName, bus.pubsubqueues[queueName].exchangeName, handler.routingKey);
+      if (bus[queueType][queueName].listening) {
+        bus[queueType][queueName].listenChannel.bindQueue(queueName, bus[queueType][queueName].exchangeName, handler.routingKey);
       } else {
-        bus.pubsubqueues[queueName].on('listening', function () {
-          bus.pubsubqueues[queueName].listenChannel.bindQueue(queueName, bus.pubsubqueues[queueName].exchangeName, handler.routingKey);
-        })
+        bus[queueType][queueName].on('listening', function () {
+          bus[queueType][queueName].listenChannel.bindQueue(queueName, bus[queueType][queueName].exchangeName, handler.routingKey);
+        });
       }
 
     }

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function registerPipeline (options, pipeline) {
 
     if (pipeline.size > 1) {
       handlers = pipeline.handlers.filter(function (handler) {
-        return handler.routingKey === msg.type ||
+        return msg.type.match(handler.routingKey) ||
                (handler.type !== undefined && handler.type === msg.type) ||
                (handler.where !== undefined && handler.where && handler.where(msg));
       });

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function registerPipeline (options, pipeline) {
 
     if (pipeline.size > 1) {
       handlers = pipeline.handlers.filter(function (handler) {
-        return msg.type.match(handler.routingKey) ||
+        return (handler.routingKey !== undefined && msg.type.match(handler.routingKey)) ||
                (handler.type !== undefined && handler.type === msg.type) ||
                (handler.where !== undefined && handler.where && handler.where(msg));
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicebus-register-handlers",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "module for registering all servicebus handlers in a folder, according to convention",
   "main": "index.js",
   "scripts": {
@@ -26,5 +26,10 @@
     "debug": "^2.2.0",
     "extend": "^3.0.0",
     "objectify-folder": "0.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5",
+    "should": "^8.2.1",
+    "sinon": "^1.17.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -9,9 +9,17 @@ var bus = {
 
 var mockbus = {
   listen: function (key, event) {
+    this.queues[key] = {
+      listening: false,
+      on: function () {}
+    };
     bus.listen(key, event);
   },
   subscribe: function (key, event) {
+    this.pubsubqueues[key] = {
+      listening: false,
+      on: function () {}
+    };
     bus.subscribe(key, event);
   },
   queues: {},

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,42 @@
+require('should');
+var registerHandlers = require('../index');
+var sinon = require('sinon');
+
+var bus = {
+  listen: sinon.spy(),
+  subscribe: sinon.spy()
+};
+
+var mockbus = {
+  listen: function (key, event) {
+    bus.listen(key, event);
+  },
+  subscribe: function (key, event) {
+    bus.subscribe(key, event);
+  },
+  queues: {},
+  pubsubqueues: {},
+  correlationId: function () {}
+}
+
+describe('register-handlers', function () {
+  it('should register simple listen', function () {
+
+    var registered = registerHandlers({
+      bus: mockbus,
+      handlers: [ {
+        subscribe: function () {}
+      }]
+    });
+
+  });
+
+  it.only('should register entire folder', function () {
+    var registered = registerHandlers({
+      bus: mockbus,
+      path: './test/support'
+    });
+
+    // console.log(require('util').inspect(registered, null, Infinity))
+  });
+});

--- a/test/support/one.js
+++ b/test/support/one.js
@@ -1,0 +1,5 @@
+module.exports.queueName = 'one';
+
+module.exports.listen = function () {
+  // no op
+}

--- a/test/support/three.js
+++ b/test/support/three.js
@@ -1,0 +1,9 @@
+module.exports.queueName = 'one';
+
+module.exports.routingKey = 'two.*';
+
+module.exports.type = 'first';
+
+module.exports.subscribe = function () {
+  // no op
+}

--- a/test/support/two.js
+++ b/test/support/two.js
@@ -1,0 +1,5 @@
+module.exports.routingKey = 'two.*';
+
+module.exports.subscribe = function () {
+  // no op
+}


### PR DESCRIPTION
this allows subscribes and listens to share queues, or subscribes with differing routing keys to share queues. refactor also improves code quality
