### PR TITLE
Feat: api aliases with tests for simplified api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
+  - "9"
+  - "8"
   - "6"
-  - "6.1"
   - "5.11"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ automatically be set to true.
 You may specify you command handlers by simply exporting a `command` property
 and a `listen` event.
 
+When you do so a `queueName` will be implied from the command name, and `ack` will be set to `true`
+
 ```
 module.exports.command = 'domain.command';
 
@@ -101,6 +103,8 @@ export const listen = function (command, cb) {
 
 You may specify you event handlers by simply exporting a `event` property
 and a `subscribe` event.
+
+When you do so a `routingKey` will be implied from the event name, and `ack` will be set to `true`
 
 ```
 module.exports.event = 'domain.event';

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports.subscribe = function (event, cb) {
 
 ## Command/Event API
 
-Servicebus is often using in CQRS systems, so a simplified API is exposed to
+Servicebus is often used in CQRS systems, so a simplified API is exposed to
 simplify it's usage for this pattern.
 
 When using either `command` or `event` keys as exports, the option `ack` will

--- a/README.md
+++ b/README.md
@@ -63,3 +63,95 @@ module.exports.subscribe = function (event, cb) {
   cb(); 
 };
 ```
+
+## Command/Event API
+
+Servicebus is often using in CQRS systems, so a simplified API is exposed to
+simplify it's usage for this pattern.
+
+When using either `command` or `event` keys as exports, the option `ack` will
+automatically be set to true.
+
+### Commands
+
+You may specify you command handlers by simply exporting a `command` property
+and a `listen` event.
+
+```
+module.exports.command = 'domain.command';
+
+module.exports.listen = function (command, cb) {
+  // no op
+}
+```
+
+With modules:
+```
+export const command = 'domain.command'
+
+export const listen = function (command, cb) {
+  const { id, product } = command.data
+  // do something
+  cb()
+}
+
+```
+
+### Events
+
+You may specify you event handlers by simply exporting a `event` property
+and a `subscribe` event.
+
+```
+module.exports.event = 'domain.event';
+
+module.exports.subscribe = function (event, cb) {
+  // no op
+}
+```
+
+With modules:
+```
+export const event = 'domain.event'
+
+export const subscribe = function (event, cb) {
+  const { id, product } = event.data
+  // do something
+  cb()
+}
+
+```
+
+## Module support
+
+MJS modules have recently been introduced to the Javascript ecosystem, however, you
+may not use a combination of both. When using MJS, it's necessary to use dynamic imports.
+
+This will be done automatically for you when you specify the option `modules` to be `true`
+in the initial registerHandlers call.
+
+```
+import path from 'path'
+import log from 'llog'
+import errortrap from 'errortrap'
+import registerHandlers from 'servicebus-register-handlers'
+import sbc from 'servicebus-bus-common';
+import { config } from '../config.mjs'
+import server from 'express-api-common'
+
+errortrap()
+
+const bus = sbc.makeBus(config)
+const { queuePrefix } = config
+
+registerHandlers({
+  bus,
+  path:  path.resolve(process.cwd(), 'handlers'),
+  modules: true,
+  queuePrefix
+})
+
+server.start()
+
+log.info('service is running')
+```

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ export const subscribe = function (event, cb) {
 MJS modules have recently been introduced to the Javascript ecosystem, however, you
 may not use a combination of both. When using MJS, it's necessary to use dynamic imports.
 
-This will be done automatically for you when you specify the option `modules` to be `true`
-in the initial registerHandlers call.
+This will be done automatically for you when you specify the option `modules` to be `true` in the initial registerHandlers call.
 
 ```
 import path from 'path'

--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ function prepareOptions (options) {
   if ( ! options.handlers && ! options.path) throw new Error('register-handlers requires a folder path or object of required modules');
 
   if (options.path) {
+
+    if (options.modules) {
+      objectifyFolder = require('objectify-folder/modules')
+    } 
     var i = 0;
     var handlers = objectifyFolder({
       fn: function (mod, result) {
@@ -76,7 +80,7 @@ function prepareOptions (options) {
       },
       path: options.path
     });
-
+  
   } else if (options.handlers) {
     options.handlers.forEach(function (handler) {
       addHandler(options.pipelines, handler);

--- a/index.js
+++ b/index.js
@@ -38,19 +38,13 @@ function Handler (options) {
   if (options.subscribe && ! (options.routingKey || options.event)) throw new Error('module.exports.subscribe must be accompanied by a module.exports.routingKey specification.')
   if (options.listen && options.subscribe) throw new Error('module.exports.listen and module.exports.subscribe cannot both be specified on a handler.')
 
-  this.ack = options.ack;
+  this.ack = options.ack ? options.ack : (options.command || options.event) ? true : undefined;
   this.listen = options.listen;
   this.queueName = options.queueName || options.command;
   this.routingKey = options.routingKey || options.event;
   this.subscribe = options.subscribe;
   this.type = options.type;
   this.where = options.where;
-
-  // if using the "command" and "event" simplified API
-  // default ack to true
-  if (options.command || options.event) {
-    this.ack = this.ack || true
-  }
 }
 
 function addHandler (pipelines, handler) {
@@ -226,3 +220,5 @@ module.exports = function (options) {
   return options;
 
 };
+
+module.exports.Handler = Handler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,341 @@
+{
+  "name": "servicebus-register-handlers",
+  "version": "0.1.7",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "amqp-match": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/amqp-match/-/amqp-match-0.0.0.tgz",
+      "integrity": "sha1-aLa2m3BqYhHbJqICbC1ney2Lq7s="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "objectify-folder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/objectify-folder/-/objectify-folder-1.1.0.tgz",
+      "integrity": "sha1-Nr/NzDROLDuQP+z8v55DVV2Un88=",
+      "requires": {
+        "debug": "^2.2.0",
+        "glob": "^7.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "should": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-8.4.0.tgz",
+      "integrity": "sha1-XmCInT5kS73Tl6MM00+tKPz5C8A=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.8.0",
+        "should-format": "0.3.2",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.8.0",
+      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.8.0.tgz",
+      "integrity": "sha1-o/BXMv9FusG3ukEvhAiFaBlkEpk=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.2.tgz",
+      "integrity": "sha1-pZgx4Bot3uFJkRvHFIvlyAMZ4f8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+      "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -102,5 +102,35 @@ describe('register-handlers', function () {
     registered.pipelines['domain.event'].should.have.property('routingKey', 'domain.event');
     registered.pipelines['domain.event'].should.have.property('size', 1);
   });
+
+  it('Handler constructor options', () => {
+    let routingKeyHandler = new registerHandlers.Handler({
+      routingKey: 'r.k',
+      subscribe: function(){}
+    })
+    routingKeyHandler.should.have.property('routingKey', 'r.k')
+    routingKeyHandler.should.have.property('ack', undefined)
+
+    let eventHandler = new registerHandlers.Handler({
+      event: 'r.k',
+      subscribe: function(){}
+    })
+    eventHandler.should.have.property('routingKey', 'r.k')
+    eventHandler.should.have.property('ack', true)
+
+    let queueNameHandler = new registerHandlers.Handler({
+      queueName: 'q.n',
+      listen: function(){}
+    })
+    queueNameHandler.should.have.property('queueName', 'q.n')
+    queueNameHandler.should.have.property('ack', undefined)
+
+    let commandHandler = new registerHandlers.Handler({
+      command: 'q.n',
+      listen: function(){}
+    })
+    commandHandler.should.have.property('queueName', 'q.n')
+    commandHandler.should.have.property('ack', true)
+  })
   
 });

--- a/test/index.js
+++ b/test/index.js
@@ -104,28 +104,28 @@ describe('register-handlers', function () {
   });
 
   it('Handler constructor options', () => {
-    let routingKeyHandler = new registerHandlers.Handler({
+    var routingKeyHandler = new registerHandlers.Handler({
       routingKey: 'r.k',
       subscribe: function(){}
     })
     routingKeyHandler.should.have.property('routingKey', 'r.k')
     routingKeyHandler.should.have.property('ack', undefined)
 
-    let eventHandler = new registerHandlers.Handler({
+    var eventHandler = new registerHandlers.Handler({
       event: 'r.k',
       subscribe: function(){}
     })
     eventHandler.should.have.property('routingKey', 'r.k')
     eventHandler.should.have.property('ack', true)
 
-    let queueNameHandler = new registerHandlers.Handler({
+    var queueNameHandler = new registerHandlers.Handler({
       queueName: 'q.n',
       listen: function(){}
     })
     queueNameHandler.should.have.property('queueName', 'q.n')
     queueNameHandler.should.have.property('ack', undefined)
 
-    let commandHandler = new registerHandlers.Handler({
+    var commandHandler = new registerHandlers.Handler({
       command: 'q.n',
       listen: function(){}
     })

--- a/test/index.js
+++ b/test/index.js
@@ -87,5 +87,20 @@ describe('register-handlers', function () {
     registered.pipelines['six'].should.have.property('size', 1);
 
   });
+
+  it('simplified api should map to correct values and default ack to true', function () {
+    var registered = registerHandlers({
+      bus: mockbus,
+      path: './test/support'
+    });
+
+    registered.pipelines.should.have.property('domain.command');
+    registered.pipelines['domain.command'].should.have.property('queueName', 'domain.command');
+    registered.pipelines['domain.command'].should.have.property('size', 1);
+
+    registered.pipelines.should.have.property('domain.event');
+    registered.pipelines['domain.event'].should.have.property('routingKey', 'domain.event');
+    registered.pipelines['domain.event'].should.have.property('size', 1);
+  });
   
 });

--- a/test/support/command.js
+++ b/test/support/command.js
@@ -1,0 +1,5 @@
+module.exports.command = 'domain.command';
+
+module.exports.listen = function () {
+  // no op
+}

--- a/test/support/event.js
+++ b/test/support/event.js
@@ -1,0 +1,5 @@
+module.exports.event = 'domain.event';
+
+module.exports.subscribe = function () {
+  // no op
+}


### PR DESCRIPTION
(from convo)
can we make ack true by default
opt-out instead
and, alias `queueName` with `command`, and alias `routingKey` with `event`

or `commandName` and `eventName`
it's hard to remember which goes with which
I think it would make the API look sexier and feel a little easier to use
```
export const command = 'context.domain.command'

export const listen = function (command, cb) {
  log.info('command handler for ', command.type)
  const { id, product } = command.data
  log.info({ id, product })
  cb()
}
```
```
export const event = 'context.domain.event'

export const subscribe = function (event, cb) {
  log.info('event handler for ', event.type)
  const { id, product } = event.data
  log.info({ id, product })
  cb()
}
```
